### PR TITLE
Remove url from track

### DIFF
--- a/app/assets/stylesheets/admin/admin-track-form.css.scss
+++ b/app/assets/stylesheets/admin/admin-track-form.css.scss
@@ -13,7 +13,7 @@
   }
 }
 
-.admin-track-form__url {
+.admin-track-form__filename {
   input {
     width: 90%;
   }

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -81,7 +81,7 @@ module Admin
     def track_params
       recorded_on = recorded_on_from_params
       attrs = params.require(:track).permit(:description, :display_title,
-                                            :playlist, :title, :url, :recorded_on,
+                                            :playlist, :title, :filename, :recorded_on,
                                             :tag_list, :style_list, :author, :published)
       attrs[:recorded_on] = recorded_on if recorded_on
       attrs

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -4,8 +4,7 @@ require Rails.root.join('lib', 's3')
 
 class Track < ApplicationRecord
   validates :title, presence: true
-  validates :url, url: true, presence: true
-
+  validates :filename, presence: true
   acts_as_taggable
   acts_as_taggable_on :styles
 

--- a/app/views/admin/tracks/_form.slim
+++ b/app/views/admin/tracks/_form.slim
@@ -32,7 +32,7 @@
     - recorded_on = @track.recorded_on
     = text_field_tag :recorded_on_day, (recorded_on.present? ? recorded_on.strftime("%d %b, %Y") : ''), class: 'datepicker', placeholder: "Date"
     = text_field_tag :recorded_on_time, (recorded_on.present? ? recorded_on.strftime("%I:%M%p") : ''), class: 'timepicker', placeholder: "Time"
-  = f.input :url, hint: "Full URL to the music file (on Amazon S3 or elsewhere).", wrapper_html: { class: "admin-track-form__url" }
+  = f.input :filename, hint: "Filename on Amazon S3 without leading slash.", wrapper_html: { class: "admin-track-form__filename" }
   = f.input :playlist, hint: "Keep it simple.  Artist - Track title, or something similar.  Each track should be on a new line.  You can use <a href='http://daringfireball.net/projects/markdown/syntax'>markdown</a> for formatting if you want to get fancy.".html_safe
   = f.input :description, hint: "Describe the track.  You can use <a href='http://daringfireball.net/projects/markdown/syntax'>markdown</a> for formatting if you want to get fancy.".html_safe
   = f.button :submit

--- a/bin/pg_restore_to_development.sh
+++ b/bin/pg_restore_to_development.sh
@@ -1,0 +1,2 @@
+#!/bin/bash 
+pg_restore --verbose --clean --no-acl --no-owner -h localhost -d selectors_choice_dev $1

--- a/db/migrate/20200112011714_remove_url_from_tracks.rb
+++ b/db/migrate/20200112011714_remove_url_from_tracks.rb
@@ -1,0 +1,4 @@
+class RemoveUrlFromTracks < ActiveRecord::Migration[6.0]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_05_010611) do
+ActiveRecord::Schema.define(version: 2020_01_12_011714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Problem
-------

We moved to using filename in a previous PR.  As it turns out, the url
is no longer necessary.  Additionally, the move broke the app because we
were never saving filename for the new records (or with update).

Solution
--------

Update the track form to save filename instead of url and remove the url
from the model.