### PR TITLE
Actually remove `url` field from Track

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem 'rspec-rails', '4.0.0.beta3'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
+  gem 'shoulda-matchers'
   gem 'simplecov', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1136,6 +1136,8 @@ GEM
       tilt
     select2-rails (3.5.10)
       thor (~> 0.14)
+    shoulda-matchers (4.2.0)
+      activesupport (>= 4.2.0)
     simple_form (5.0.1)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -1204,6 +1206,7 @@ DEPENDENCIES
   rubocop-performance
   sassc-rails
   select2-rails (~> 3.x)
+  shoulda-matchers
   simple_form
   simplecov
   slim

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -32,7 +32,7 @@ module Admin
     def clone
       @track = Track.find(params[:id]).dup
       @track.published = false
-      @track.url = ''
+      @track.filename = ''
       render 'new'
     end
 
@@ -83,8 +83,16 @@ module Admin
       attrs = params.require(:track).permit(:description, :display_title,
                                             :playlist, :title, :filename, :recorded_on,
                                             :tag_list, :style_list, :author, :published)
+      attrs[:tag_list] = process_tag_params(attrs[:tag_list])
+      attrs[:style_list] = process_tag_params(attrs[:style_list])
       attrs[:recorded_on] = recorded_on if recorded_on
       attrs
+    end
+
+    def process_tag_params(tag_list)
+      return unless tag_list.present?
+
+      tag_list.split(',').map(&:strip)
     end
 
     def recorded_on_from_params

--- a/app/views/admin/tracks/show.slim
+++ b/app/views/admin/tracks/show.slim
@@ -24,8 +24,12 @@ ul.admin-track-info
       = @track.recorded_on unless @track.recorded_on.blank?
 
   li
-    .label URL
-    .value = @track.url
+    .label Filename
+    .value = @track.filename
+
+  li
+    .label Signed URL
+    .value = @track.signed_url
 
   li
     .label Tags

--- a/db/migrate/20200112011715_remove_url_from_tracks_take_two.rb
+++ b/db/migrate/20200112011715_remove_url_from_tracks_take_two.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveUrlFromTracksTakeTwo < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :tracks, :url
+  end
+
+  def down
+    add_column :tracks, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_12_011714) do
+ActiveRecord::Schema.define(version: 2020_01_12_011715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2020_01_12_011714) do
     t.text "playlist"
     t.text "description"
     t.datetime "recorded_on"
-    t.string "url", limit: 255
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "author", limit: 255

--- a/spec/controllers/admin/tracks_controller_spec.rb
+++ b/spec/controllers/admin/tracks_controller_spec.rb
@@ -46,7 +46,7 @@ describe Admin::TracksController do
           expect(cloned_track.send(fld)).to eql track.send(fld)
         end
         expect(cloned_track.published).to be_falsey
-        expect(cloned_track.url).to be_empty
+        expect(cloned_track.filename).to be_empty
       end
     end
 

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     title { |n| "hot new mix #{n}" }
     author { |_n| ['Mr Rogers', 'Soul Suspect'].cycle }
     filename { |n| "rock it #{n}.mp3" }
-    url { "http://s3.amazon.com/selectors_choice/#{filename}" }
     recorded_on { (Time.now - rand(50).days) }
     published { true }
     description { 'set description *with emphasis*' }

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -4,19 +4,6 @@ require 'rails_helper'
 
 describe Track do
   describe 'validations' do
-    it 's3 urls are valid' do
-      valid_urls = %w[http://whatever.com/file.mp3 http://overthere.com/and/in/a/deep/dir/file.mp3
-                      https://selectors_choice.s3.amazonaws.com/missioncliffs/20151002/20151002_1.mp3]
-      valid_urls.each do |url|
-        track = Track.new url: url
-        expect(track.errors[:url]).to be_blank
-      end
-    end
+    it { is_expected.to validate_presence_of(:filename) }
   end
-
-  # it 'signs a filename when getting a url' do
-  #   Aws::S3::Presigner
-  #   track = create(:track)
-  #   url = track.signed_url
-  # end
 end

--- a/spec/support/mock_s3.rb
+++ b/spec/support/mock_s3.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../lib/s3.rb'
+
 def mock_s3(client_stubs = {})
   allow(SelectorsChoice::S3).to receive(:new).and_return(
     double(SelectorsChoice::S3, { get_presigned_url: 'presigned_url_${SecureRandom.hex(10)}' }.merge(client_stubs))

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/views/admin/tracks/show.html.erb_spec.rb
+++ b/spec/views/admin/tracks/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe 'admin/tracks/show' do
   before(:each) do
+    mock_s3
     @track = assign(:track, FactoryBot.create(:track,
                                               title: 'Title',
                                               display_title: 'Display Title',


### PR DESCRIPTION
Problem
-------

We made all the code use filename, but we checked in a migration that
was empty.

Solution
--------

Fill the migration and upgrade tests and views to match the fact that we
do not have a url field.