### PR TITLE
Add trailing comma rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,7 +132,19 @@ Style/StringLiteralsInInterpolation:
 
 Style/StructInheritance:
   Enabled: true
-  
+
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
 #
 # Rails Cops
 #

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -9,11 +9,11 @@ class AdminController < ApplicationController
     @track_counts = {
       all: Track.count,
       published: Track.published.count,
-      unpublished: Track.unpublished.count
+      unpublished: Track.unpublished.count,
     }
     @track_tags = {
       tags: Track.tag_counts_on(:tags),
-      styles: Track.tag_counts_on(:styles)
+      styles: Track.tag_counts_on(:styles),
     }
   end
 end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -15,7 +15,7 @@ class Track < ApplicationRecord
   def signed_url
     SelectorsChoice::CloudFront.new.get_presigned_url(
       filename,
-      expires: Time.current + Rails.configuration.track_expiry_in_seconds.seconds
+      expires: Time.current + Rails.configuration.track_expiry_in_seconds.seconds,
     )
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/lib/cloud_front.rb
+++ b/lib/cloud_front.rb
@@ -10,7 +10,7 @@ module SelectorsChoice
       opts = {
         key_pair_id: ENV['AWS_KEY_PAIR_ID'],
         private_key_path: ENV['AWS_PRIVATE_KEY_PATH'],
-        private_key: unpack_key(ENV['AWS_PRIVATE_KEY'])
+        private_key: unpack_key(ENV['AWS_PRIVATE_KEY']),
       }.compact
       @signer = Aws::CloudFront::UrlSigner.new(**opts)
     end

--- a/spec/lib/cloud_front_spec.rb
+++ b/spec/lib/cloud_front_spec.rb
@@ -19,7 +19,7 @@ describe SelectorsChoice::CloudFront do
   it 'sets up the cloudfront signer with the right options' do
     with_modified_env(
       AWS_PRIVATE_KEY_PATH: 'the pk.pem path',
-      AWS_KEY_PAIR_ID: 'my key pair id'
+      AWS_KEY_PAIR_ID: 'my key pair id',
     ) do
       described_class.new
       expect(Aws::CloudFront::UrlSigner).to have_received(:new).with(key_pair_id: 'my key pair id',
@@ -30,7 +30,7 @@ describe SelectorsChoice::CloudFront do
   it 'unpacks the PRIVATE_KEY if that was provided' do
     with_modified_env(
       AWS_PRIVATE_KEY: 'abc\ndef rbg\n',
-      AWS_KEY_PAIR_ID: 'my key pair id'
+      AWS_KEY_PAIR_ID: 'my key pair id',
     ) do
       described_class.new
       expect(Aws::CloudFront::UrlSigner).to have_received(:new).with(key_pair_id: 'my key pair id',
@@ -42,7 +42,7 @@ describe SelectorsChoice::CloudFront do
     it 'builds the cloudfront url and returns a signed version of that' do
       with_modified_env(
         AWS_CLOUD_FRONT_DOMAIN: 'my-cloudfront-domain',
-        AWS_KEY_PAIR_ID: 'my key pair id'
+        AWS_KEY_PAIR_ID: 'my key pair id',
       ) do
         described_class.new.get_presigned_url('abc def.mp3', whatever: 'opts')
         expect(mock_signer).to have_received(:signed_url)

--- a/spec/support/mock_cloud_front.rb
+++ b/spec/support/mock_cloud_front.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/cloud_front'
 
 def mock_cloud_front(client_stubs = {})
   mock_service = double(SelectorsChoice::CloudFront, {
-    get_presigned_url: "presigned_url_#{SecureRandom.hex(10)}"
+    get_presigned_url: "presigned_url_#{SecureRandom.hex(10)}",
   }.merge(client_stubs))
   allow(SelectorsChoice::CloudFront).to receive(:new).and_return(mock_service)
   mock_service


### PR DESCRIPTION
Adds trailing comma rules for rubocop so we get trailing commas everywhere.

* One commit to add the new rules
* One commit to run the autocorrect