### PR TITLE
Fix download link

### DIFF
--- a/app/assets/stylesheets/application/tracks.css.scss
+++ b/app/assets/stylesheets/application/tracks.css.scss
@@ -112,6 +112,7 @@ ul .track {
     }
   }
   .bd, .ft {
+    position: relative;
     margin-top: 10px;
   }
   .ft {
@@ -184,7 +185,7 @@ ul .track {
     background-color: $purple_background;
     display: inline-block;
   }
- 
+
 }
 
 .audio .pre-audio {


### PR DESCRIPTION
Link was not properly positioned so it was ending up on the
top left corner of the page, not of each track

Fix: `position: relative`