### PR TITLE
Add publish button on the list page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-collection_matchers'
   gem 'rspec-rails'
+  gem 'rspec-retry'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,8 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.13.3)
     rubocop (1.75.6)
       json (~> 2.3)
@@ -482,6 +484,7 @@ DEPENDENCIES
   rdiscount
   rspec-collection_matchers
   rspec-rails
+  rspec-retry
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/controllers/admin/tracks_controller.rb
+++ b/app/controllers/admin/tracks_controller.rb
@@ -66,6 +66,12 @@ module Admin
       end
     end
 
+    def publish
+      track = Track.find(params[:id])
+      track.update!(published: true) unless track.published
+      redirect_to admin_tracks_path, notice: "#{track.title} has been published!"
+    end
+
     def destroy
       @track = Track.find(params[:id])
       @track.destroy

--- a/app/frontend/stylesheets/application/loveli-icons.css.scss
+++ b/app/frontend/stylesheets/application/loveli-icons.css.scss
@@ -71,3 +71,6 @@ $column_size: -35px;
 .icon.icon-feed {
   @include icon_position(3,5);
 }
+.icon.icon-lightning {
+  @include icon_position(3,7);
+}

--- a/app/views/admin/tracks/_tracks_table.slim
+++ b/app/views/admin/tracks/_tracks_table.slim
@@ -32,4 +32,5 @@ table.admin-tracks__table.striped
           = link_to_dark_icon 'show', admin_track_path(track)
           = link_to_dark_icon 'edit', edit_admin_track_path(track)
           = link_to_dark_icon 'clone', clone_admin_track_path(track)
+          = link_to_dark_icon 'lightning', publish_admin_track_path(track), method: :post, title: 'publish' unless track.published
           = link_to_dark_icon 'delete', admin_track_path(track), method: :delete, data: { confirm: 'Are you sure?' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :tracks do
       member do
         get :clone
+        post :publish
       end
     end
   end

--- a/spec/controllers/admin/tracks_controller_spec.rb
+++ b/spec/controllers/admin/tracks_controller_spec.rb
@@ -183,6 +183,27 @@ describe Admin::TracksController do
       end
     end
 
+    describe 'POST publish' do
+      let(:unpublished_track) { FactoryBot.create(:track, updated_at: 1.year.ago.to_date) }
+
+      it 'marks a track published' do
+        expect {
+          post :publish, params: { id: unpublished_track.id }
+        }.to change { unpublished_track.reload.published }.from(nil).to(true)
+        expect(unpublished_track.updated_at).to be_within(1.day).of(Time.current)
+      end
+
+      context 'if the track was already published' do
+        let(:published_track) { FactoryBot.create(:track, :published, updated_at: 1.year.ago) }
+        it 'does nothing' do
+          expect {
+            post :publish, params: { id: published_track.id }
+          }.not_to change { published_track.reload.published }
+          expect(published_track.updated_at.to_date).to eq 1.year.ago.to_date
+        end
+      end
+    end
+
     describe 'DELETE destroy' do
       before do
         @track = Track.create! valid_attributes

--- a/spec/features/admin_tracks_spec.rb
+++ b/spec/features/admin_tracks_spec.rb
@@ -29,7 +29,7 @@ feature 'Admin' do
       expect(page).to have_content 'In the wings:2'
     end
 
-    scenario 'can add a track', js: true do
+    scenario 'can add a track and publish it', js: true do
       click_on 'tracks'
 
       click_on 'add new track'
@@ -46,11 +46,14 @@ feature 'Admin' do
       fill_in :recorded_on_time, with: '2:00pm'
       fill_in :track_filename, with: 'the_dir/the_file.mp3'
 
-      #      sleep 1
       click_on 'Create Track'
 
       expect(page).to have_content 'track with recorded time(draft)'
       expect(page).to have_content '2020-10-02'
+
+      visit admin_tracks_path
+      click_on_last 'publish'
+      expect(page).to have_content 'track with recorded time has been published!'
     end
 
     scenario 'can add a track with tags', js: true do

--- a/spec/support/sign_in_admin.rb
+++ b/spec/support/sign_in_admin.rb
@@ -9,6 +9,7 @@ module SignInAdmin
       fill_in :session_email, with: admin.email
       fill_in :session_password, with: password
       click_on 'Sign in'
+      expect(page).to have_current_path(admin_index_path)
     end
   end
 end


### PR DESCRIPTION
problem
----

when we upload tracks, often there will be three or 4 that are uploaded together unpublished
and instead of going back to edit each one, we want a quick "publish" trigger.

solution
------

add a publish button on the tracks list for the admin
